### PR TITLE
Fix Entry default initialization

### DIFF
--- a/double-hashing/main.cpp
+++ b/double-hashing/main.cpp
@@ -20,7 +20,7 @@ struct Entry {
     K key;
     V value;
     SlotState state;
-    Entry() : state(EMPTY) {}
+    Entry() : key(), value(), state(EMPTY) {}
     Entry(const K& k, const V& v, SlotState s) : key(k), value(v), state(s) {}
 };
 


### PR DESCRIPTION
## Summary
- initialize `Entry` members in the default constructor

## Testing
- `g++ -std=c++17 -O2 main.cpp -o double-hashing`
- `./double-hashing` *(fails: prompts for input and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686508b049a88322a74a772965f54235