### PR TITLE
Fix overflow causing vector subscript error

### DIFF
--- a/double-hashing/main.cpp
+++ b/double-hashing/main.cpp
@@ -211,14 +211,19 @@ public:
 private:
     // Tính vị trí cần kiểm tra tiếp theo tùy theo phương pháp dò
     int calcProbe(int base, int step, K key) const {
+        long long res;
         switch (type) {
         case Probing::LINEAR:
-            return (base + step) % sz;
+            res = base + static_cast<long long>(step);
+            break;
         case Probing::QUADRATIC:
-            return (base + step * step) % sz;
+            res = base + 1LL * step * step;
+            break;
         default:
-            return (base + step * (prime - (key % prime))) % sz;
+            res = base + 1LL * step * (prime - (key % prime));
+            break;
         }
+        return static_cast<int>(res % sz);
     }
 };
 


### PR DESCRIPTION
## Summary
- fix integer overflow in `calcProbe` that could lead to invalid vector indices

## Testing
- `g++ -std=c++17 -O2 main.cpp -o double-hashing`
- `./double-hashing` *(manual run)*

------
https://chatgpt.com/codex/tasks/task_e_68652763d9a8832291e8f2fef3c324ce